### PR TITLE
[1_14] Revert the removal of inline for command_rep

### DIFF
--- a/Kernel/Abstractions/command.hpp
+++ b/Kernel/Abstractions/command.hpp
@@ -19,9 +19,9 @@ class command_rep : public abstract_struct {
 public:
   inline command_rep () { TM_DEBUG (command_count++); }
   inline virtual ~command_rep () { TM_DEBUG (command_count--); }
-  virtual tm_ostream& print (tm_ostream& out);
-  virtual void        apply ()= 0;
-  virtual void        apply (object args);
+  inline virtual tm_ostream& print (tm_ostream& out);
+  virtual void               apply ()= 0;
+  virtual void               apply (object args);
 };
 
 class command {


### PR DESCRIPTION
Seehttps://github.com/XmacsLabs/mogan/pull/1804

Because command.hpp has been migrated to moebius, we have to revert it accordingly.