### PR TITLE
[1_13] Revert the removal of inline for patch_rep

### DIFF
--- a/Data/History/patch.hpp
+++ b/Data/History/patch.hpp
@@ -28,23 +28,23 @@ class patch;
 class patch_rep : public abstract_struct {
 public:
   inline patch_rep () {}
-  virtual ~patch_rep () {}
-  virtual int          get_type ()= 0;
-  virtual int          get_arity () { return 0; }
-  virtual patch        get_child (int i);
-  virtual modification get_modification () {
+  inline virtual ~patch_rep () {}
+  inline virtual int          get_type ()= 0;
+  inline virtual int          get_arity () { return 0; }
+  inline virtual patch        get_child (int i);
+  inline virtual modification get_modification () {
     TM_FAILED ("not a modification");
     return mod_assign (path (), "");
   }
-  virtual modification get_inverse () {
+  inline virtual modification get_inverse () {
     TM_FAILED ("not a modification");
     return mod_assign (path (), "");
   }
-  virtual bool get_birth () {
+  inline virtual bool get_birth () {
     TM_FAILED ("not a birth");
     return false;
   }
-  virtual double get_author () { return -1; }
+  inline virtual double get_author () { return -1; }
 };
 
 class patch {


### PR DESCRIPTION
See https://github.com/XmacsLabs/mogan/pull/1804

Because patch.hpp has been migrated to moebius, we have to revert it accordingly.