### PR TITLE
[1_22] upgrade lolly to 1.4.27

### DIFF
--- a/xmake/packages/l/lolly/xmake.lua
+++ b/xmake/packages/l/lolly/xmake.lua
@@ -24,7 +24,7 @@ package("lolly")
 
     add_urls("https://github.com/XmacsLabs/lolly.git")
     add_urls("https://gitee.com/XmacsLabs/lolly.git")
-    add_versions("1.4.26", "v1.4.26")
+    add_versions("1.4.27", "v1.4.27")
 
     add_deps("tbox")
     if not is_plat("wasm") then


### PR DESCRIPTION
## Performance

### Before
|        ns/character |         character/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               26.92 |       37,150,771.29 |    2.8% |      0.04 | `parsing large group of simple element`
|               31.18 |       32,073,540.99 |    1.9% |      0.05 | `serializing large group of simple element`
|               48.78 |       20,499,900.93 |    2.5% |      0.07 | `parsing group of complex tree`
|               55.67 |       17,962,913.36 |    1.8% |      0.08 | `parsing single tree with complex structure`
|               34.32 |       29,139,808.31 |    1.5% |      0.05 | `serializing group of complex tree`
|               32.57 |       30,706,217.56 |    1.6% |      0.05 | `serializing single tree with complex structure`

### After
|        ns/character |         character/s |    err% |     total | benchmark
|--------------------:|--------------------:|--------:|----------:|:----------
|               26.88 |       37,204,964.49 |    2.0% |      0.04 | `parsing large group of simple element`
|               28.82 |       34,699,794.81 |    0.6% |      0.05 | `serializing large group of simple element`
|               48.51 |       20,614,859.09 |    0.9% |      0.07 | `parsing group of complex tree`
|               52.53 |       19,035,944.20 |    1.0% |      0.08 | `parsing single tree with complex structure`
|               33.56 |       29,799,403.35 |    1.4% |      0.05 | `serializing group of complex tree`
|               30.82 |       32,449,871.18 |    2.7% |      0.05 | `serializing single tree with complex structure`